### PR TITLE
Add option to enabe/disable the tests

### DIFF
--- a/libsakura/CMakeLists.txt
+++ b/libsakura/CMakeLists.txt
@@ -77,10 +77,14 @@ endif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
 
 message(STATUS "CMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}")
 
+option(ENABLE_TEST "Enable tests using Google Test" ON)
 
-find_path(GTEST_INCLUDE_DIRS gtest/gtest.h PATHS ${CMAKE_CURRENT_SOURCE_DIR}/gtest/include)
-set(GTEST_LIBRARIES ${PROJECT_BINARY_DIR}/bingtest/libgtest.a)
-set(GTEST_MAIN_LIBRARIES ${PROJECT_BINARY_DIR}/bingtest/libgtest_main.a)
+
+if(ENABLE_TEST)
+    find_path(GTEST_INCLUDE_DIRS gtest/gtest.h PATHS ${CMAKE_CURRENT_SOURCE_DIR}/gtest/include)
+    set(GTEST_LIBRARIES ${PROJECT_BINARY_DIR}/bingtest/libgtest.a)
+    set(GTEST_MAIN_LIBRARIES ${PROJECT_BINARY_DIR}/bingtest/libgtest_main.a)
+endif(ENABLE_TEST)
 
 # sakura root directory
 set(SAKURA_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
@@ -88,8 +92,12 @@ set(SAKURA_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 #set(CMAKE_BUILD_TYPE Release)
 
 add_subdirectory(src bin)
-add_subdirectory(gtest bingtest)
-add_subdirectory(test bintest)
+
+if(ENABLE_TEST)
+    add_subdirectory(gtest bingtest)
+    add_subdirectory(test bintest)
+endif(ENABLE_TEST)
+
 if(PYTHON_BINDING)
   add_subdirectory(python-binding python-binding)
 endif(PYTHON_BINDING)

--- a/libsakura/INSTALL.txt
+++ b/libsakura/INSTALL.txt
@@ -88,7 +88,7 @@ ftp://anonymous:ftp@alma-dl.mtk.nao.ac.jp/sakura/releases/latest_src
 
 Above command creates a libsakura directory in your working directory. 
 
-3.2 Setup a Google Test framework for Sakura
+3.2 Setup a Google Test framework for Sakura (optional)
 
 Sakura library uses Google Test framework (gtest) to run unit tests.
 
@@ -107,6 +107,7 @@ In this step, you run cmake to generate Sakura build system.
 
 You might typically have to customize the cmake command line to specify:
 - where you want Sakura to be installed
+- whether you want to enable the tests
 - and where the fftw3 and Eigen libraries are installed in your system
 
 In the simplest case where compliant versions of fftw3 and Eigen are automatically found by cmake, you simply have to run:
@@ -154,6 +155,10 @@ BUILD_DOC
   Enable/disable Doxygen generation of Sakura API HTML documentation
   To disable documentation generation, add to cmake command line: -D BUILD_DOC:BOOL=OFF
 
+ENABLE_TEST
+  Enable/disable tests. You need Google test framework as explained above.
+  To disable tests add to cmake command line: -D ENABLE_TEST:BOOL=OFF
+
 3.4 Build Sakura
 
 [build]$ make
@@ -168,6 +173,7 @@ You can skip this step if you specified -D BUILD_DOC:BOOL=OFF on cmake command l
 ----------
 
 This step allows you to verify that your installation of Sakura is working correctly.
+The ENABLE_TEST option must be ON.
 
 [build]$ make test
 


### PR DESCRIPTION
This PR adds an option to enable/disable tests. That can help external users (like CASA developers) to avoid additional Google Test dependency when building the library.