### PR TITLE
Add support for pkgconfig

### DIFF
--- a/libsakura/CMakeLists.txt
+++ b/libsakura/CMakeLists.txt
@@ -93,3 +93,8 @@ add_subdirectory(test bintest)
 if(PYTHON_BINDING)
   add_subdirectory(python-binding python-binding)
 endif(PYTHON_BINDING)
+
+# Install pkg-config support file
+CONFIGURE_FILE("libsakura.pc.in" "libsakura.pc" @ONLY)
+set(LIBSAKURA_PKGCONFIG_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}/lib/pkgconfig")
+INSTALL(FILES "${CMAKE_CURRENT_BINARY_DIR}/libsakura.pc" DESTINATION "${LIBSAKURA_PKGCONFIG_INSTALL_PREFIX}")

--- a/libsakura/libsakura.pc.in
+++ b/libsakura/libsakura.pc.in
@@ -1,0 +1,12 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: Libsakura
+Description: @CMAKE_PROJECT_DESCRIPTION@
+Version: @PROJECT_VERSION@
+Requires: @pc_req_public@
+Requires.private: @pc_req_private@
+Libs: -L${libdir} -lsakura
+Cflags: -I${includedir}


### PR DESCRIPTION
This PR allows clients of libsakura to discover the compilation flags and linker flags automatically, rather than the client needing to hard-code the compiler and linker flags.