### PR TITLE
Fix setting of CMAKE_MODULE_PATH for off-source builds

### DIFF
--- a/libsakura/CMakeLists.txt
+++ b/libsakura/CMakeLists.txt
@@ -23,6 +23,9 @@
 
 cmake_minimum_required(VERSION 2.8)
 
+# List of directories to search for CMake modules
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake-modules")
+
 set(libsakura_VERSION_MAJOR 5)
 set(libsakura_VERSION_MINOR 1)
 

--- a/libsakura/src/CMakeLists.txt
+++ b/libsakura/src/CMakeLists.txt
@@ -25,8 +25,6 @@ cmake_minimum_required(VERSION 2.6)
 
 project(libsakura)
 
-set(CMAKE_MODULE_PATH ../cmake-modules CACHE STRING "List of directories to search for CMake modules")
-
 find_package(Threads)
 find_package(Eigen3 3.2.0 REQUIRED)
 find_package(Log4Cxx)


### PR DESCRIPTION
If a build is done outside the source then cmake fails because it cannot find the cmake modules.
This PR fixes that by setting the full path to the cmake modules.
To test it: create a directory in other part of the filesystem which is not below the libsakura sources and run 
`cmake path_to_libsakura_sources.`