### PR TITLE
Move project to top level CMakeLists.txt

### DIFF
--- a/libsakura/CMakeLists.txt
+++ b/libsakura/CMakeLists.txt
@@ -23,6 +23,8 @@
 
 cmake_minimum_required(VERSION 2.8)
 
+project(sakura)
+
 # List of directories to search for CMake modules
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake-modules")
 


### PR DESCRIPTION
This small patch simply moves the cmake project() clause to the top level CMakeLists.txt. Without that in modern cmake there is a warning that can be confusing for the users:

```
CMake Deprecation Warning at src/CMakeLists.txt:24 (cmake_minimum_required):
  Compatibility with CMake < 2.8.12 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.

CMake Warning (dev) at src/CMakeLists.txt:26 (project):
  Policy CMP0048 is not set: project() command manages VERSION variables.
  Run "cmake --help-policy CMP0048" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  The following variable(s) would be set to empty:

    libsakura_VERSION_MAJOR
    libsakura_VERSION_MINOR
This warning is for project developers.  Use -Wno-dev to suppress it.
```