### PR TITLE
Remove dynamic exception specifications since they are deprecated in C++11

### DIFF
--- a/libsakura/src/concurrent.cc
+++ b/libsakura/src/concurrent.cc
@@ -48,7 +48,7 @@
 
 namespace concurrent {
 /* ======================= Mutex ======================= */
-Mutex::Mutex() throw (int) {
+Mutex::Mutex() /* throw (int) */ {
 	int result = pthread_mutex_init(&mutex_, NULL);
 	if (result != 0) {
 		LOG(result);
@@ -63,7 +63,7 @@ Mutex::~Mutex() {
 	}
 }
 
-void Mutex::Lock() throw (int) {
+void Mutex::Lock() /* throw (int) */ {
 	int result = pthread_mutex_lock(&mutex_);
 	if (result != 0) {
 		LOG(result);
@@ -71,7 +71,7 @@ void Mutex::Lock() throw (int) {
 	}
 }
 
-bool Mutex::TryLock() throw (int) {
+bool Mutex::TryLock() /* throw (int) */ {
 	int result = pthread_mutex_trylock(&mutex_);
 	if (result == 0) {
 		return true;
@@ -83,7 +83,7 @@ bool Mutex::TryLock() throw (int) {
 	throw result;
 }
 
-void Mutex::Unlock() throw (int) {
+void Mutex::Unlock() /* throw (int) */ {
 	int result = pthread_mutex_unlock(&mutex_);
 	if (result != 0) {
 		LOG(result);
@@ -92,7 +92,7 @@ void Mutex::Unlock() throw (int) {
 }
 
 /* ======================= Semaphore ======================= */
-Semaphore::Semaphore(unsigned initial) throw (int) {
+Semaphore::Semaphore(unsigned initial) /* throw (int) */ {
 	//mutex_ = PTHREAD_MUTEX_INITIALIZER;
 	//condition_ = PTHREAD_COND_INITIALIZER;
 	semaphore_ = initial;
@@ -117,7 +117,7 @@ Semaphore::~Semaphore() {
 	result = pthread_cond_destroy(&condition_);
 }
 
-void Semaphore::Up(unsigned amount) throw (int) {
+void Semaphore::Up(unsigned amount) /* throw (int) */ {
 	assert(0 < amount && amount <= UINT_MAX - semaphore_);
 	int result = pthread_mutex_lock(&mutex_);
 	if (result == 0) {
@@ -139,7 +139,7 @@ void Semaphore::Up(unsigned amount) throw (int) {
 	throw result;
 }
 
-void Semaphore::Down(unsigned amount) throw (int) {
+void Semaphore::Down(unsigned amount) /* throw (int) */ {
 	assert(0 < amount);
 	int result = pthread_mutex_lock(&mutex_);
 	if (result == 0) {
@@ -170,8 +170,8 @@ void Semaphore::Down(unsigned amount) throw (int) {
 }
 
 /* ======================= Broker ======================= */
-Broker::Broker(bool (*producer)(void *context) throw (PCException),
-void (*consumer)(void *context) throw (PCException)) {
+Broker::Broker(bool (*producer)(void *context) /* throw (PCException) */ ,
+void (*consumer)(void *context) /* throw (PCException) */ ) {
 	this->producer_ = producer;
 	this->consumer_ = consumer;
 }
@@ -206,21 +206,21 @@ bool Broker::GetNestedState() {
 }
 
 void Broker::RunProducerAsMasterThread(void *context, unsigned do_ahead)
-		throw (PCException) {
+		/* throw (PCException) */ {
 	_Run(context, do_ahead, kProdAsMaster);
 }
 
 void Broker::RunConsumerAsMasterThread(void *context, unsigned do_ahead)
-		throw (PCException) {
+		/* throw (PCException) */ {
 	_Run(context, do_ahead, kConsAsMaster);
 }
 
-void Broker::Run(void *context, unsigned do_ahead) throw (PCException) {
+void Broker::Run(void *context, unsigned do_ahead) /* throw (PCException) */ {
 	_Run(context, do_ahead, kUnspecified);
 }
 
 void Broker::_Run(void *context, unsigned do_ahead, ThreadSpec thread_spec)
-		throw (PCException) {
+		/* throw (PCException) */ {
 	assert(do_ahead > 0);
 #if defined(_OPENMP)
 	PCException const *prod_ex = NULL;
@@ -313,7 +313,7 @@ void Broker::_Run(void *context, unsigned do_ahead, ThreadSpec thread_spec)
 #endif
 }
 
-void Broker::RunSequential(void *context) throw (PCException) {
+void Broker::RunSequential(void *context) /* throw (PCException) */ {
 	for (;;) {
 		bool produced = producer_(context);
 		if (!produced) {

--- a/libsakura/src/libsakura/concurrent.h
+++ b/libsakura/src/libsakura/concurrent.h
@@ -55,15 +55,15 @@ public:
 
 class Mutex {
 public:
-	Mutex() throw (int);
+	Mutex() /* throw (int) */;
 	virtual ~Mutex();
-	void Lock() throw (int);
+	void Lock() /* throw (int) */;
 	/**
 	 * Returns true if this thread could lock.
 	 * Returns false if already locked.
 	 */
-	bool TryLock() throw (int);
-	void Unlock() throw (int);
+	bool TryLock() /* throw (int) */;
+	void Unlock() /* throw (int) */;
 private:
 	Mutex(Mutex const &other);
 	Mutex &operator =(Mutex const &other);
@@ -73,10 +73,10 @@ private:
 
 class Semaphore {
 public:
-	explicit Semaphore(unsigned initial = 0U) throw (int);
+	explicit Semaphore(unsigned initial = 0U) /* throw (int) */;
 	virtual ~Semaphore();
-	void Up(unsigned amount = 1U) throw (int);
-	void Down(unsigned amount = 1U) throw (int);
+	void Up(unsigned amount = 1U) /* throw (int) */;
+	void Down(unsigned amount = 1U) /* throw (int) */;
 private:
 	Semaphore(Semaphore const &other);
 	Semaphore &operator =(Semaphore const &other);
@@ -144,7 +144,7 @@ public:
 		Reset();
 	}
 
-	virtual void Put(T const &value) throw (FullException) {
+	virtual void Put(T const &value) /* throw (FullException) */ {
 		size_t new_tail = Wrap(tail_ + 1);
 		if (head_ == new_tail) {
 			throw FullException();
@@ -153,7 +153,7 @@ public:
 		tail_ = new_tail;
 	}
 
-	virtual T Get() throw (EmptyException) {
+	virtual T Get() /* throw (EmptyException) */ {
 		if (head_ == tail_) {
 			throw EmptyException();
 		}
@@ -200,35 +200,35 @@ private:
 
 class Broker {
 public:
-	Broker(bool (*producer)(void *context) throw (PCException),
-	void (*consumer)(void *context) throw (PCException));
+	Broker(bool (*producer)(void *context) /* throw (PCException) */,
+	void (*consumer)(void *context) /* throw (PCException) */ );
 	virtual ~Broker();
 	static void EnableNested();
 	static void DisableNested();
 	static void SetNestedState(bool nested);
 	static bool GetNestedState();
 
-	virtual void Run(void *context, unsigned do_ahead = 1) throw (PCException);
+	virtual void Run(void *context, unsigned do_ahead = 1) /* throw (PCException) */;
 	virtual void RunProducerAsMasterThread(void *context, unsigned do_ahead = 1)
-			throw (PCException);
+			/* throw (PCException) */;
 	virtual void RunConsumerAsMasterThread(void *context, unsigned do_ahead = 1)
-			throw (PCException);
-	virtual void RunSequential(void *context) throw (PCException);
+			/* throw (PCException) */;
+	virtual void RunSequential(void *context) /* throw (PCException) */;
 protected:
 	enum ThreadSpec {
 		kProdAsMaster, kConsAsMaster, kUnspecified
 	};
-	bool (*producer_)(void *context) throw (PCException);
-	void (*consumer_)(void *context) throw (PCException);
+	bool (*producer_)(void *context) /* throw (PCException) */;
+	void (*consumer_)(void *context) /* throw (PCException) */;
 	virtual void _Run(void *context, unsigned do_ahead, ThreadSpec thread_spec)
-			throw (PCException);
+			/* throw (PCException) */;
 };
 
 #if 1
 template<class Context, class Product>
 class Producer {
 public:
-	virtual Product Produce(Context *ctx) throw (PCException) = 0;
+	virtual Product Produce(Context *ctx) /* throw (PCException) */ = 0;
 	virtual ~Producer() {
 	}
 };
@@ -237,7 +237,7 @@ template<class Context, class Product>
 class Consumer {
 public:
 	virtual void Consume(Context *ctx, Product const*product)
-			throw (PCException) = 0;
+			/* throw (PCException) */ = 0;
 	virtual ~Consumer() {
 	}
 };
@@ -247,10 +247,10 @@ public:
 	virtual ~ProdCons() {
 	}
 
-	virtual void RunProducerAsMasterThread(void *context) throw (PCException) = 0;
-	virtual void RunConsumerAsMasterThread(void *context) throw (PCException) = 0;
-	virtual void Produce(void *context) throw (PCException) = 0;
-	virtual void Consume(void *context) throw (PCException) = 0;
+	virtual void RunProducerAsMasterThread(void *context) /* throw (PCException) */ = 0;
+	virtual void RunConsumerAsMasterThread(void *context) /* throw (PCException) */ = 0;
+	virtual void Produce(void *context) /* throw (PCException) */ = 0;
+	virtual void Consume(void *context) /* throw (PCException) */ = 0;
 
 	/**
 	 * @ref Produce() should  call this method to

--- a/libsakura/src/libsakura/memory_manager.h
+++ b/libsakura/src/libsakura/memory_manager.h
@@ -99,7 +99,7 @@ public:
 	 */
 	template<typename T>
 	static inline void *AlignedAllocateOrException(size_t size_in_bytes,
-			T **aligned_address) throw (std::bad_alloc) {
+			T **aligned_address) /* throw (std::bad_alloc) */ {
 		assert(aligned_address != nullptr);
 		size_t alignment = LIBSAKURA_SYMBOL(GetAlignment)();
 


### PR DESCRIPTION
The throw specifications in the declaration of methods is deprecated in C++11 and will be removed in C++17.
This PR removes a number of warnings in more modern compilers and will prevent future failures when compilers set the default to C++17. 
Reference: https://en.cppreference.com/w/cpp/language/except_spec